### PR TITLE
Skeleton media queries to support mobile and tablet

### DIFF
--- a/client/components/Map/Map.jsx
+++ b/client/components/Map/Map.jsx
@@ -3,10 +3,18 @@ import { connect } from "react-redux"
 import styled from "styled-components"
 import PropTypes from "prop-types"
 import { mapOptions } from "../../lib/map"
+import { media } from "../../lib/styles"
 import { receiveMap, receiveClientLocation, receiveMarkerLocation, receiveDrawPolygon } from "./actions"
 
 const Container = styled.div`
   flex: 1 1 70%;
+
+  ${media.tablet`
+    height: 50%;
+  `}
+  ${media.mobileM`
+    height: 50%; 
+  `}
 `
 
 const MapComponent = styled.div`

--- a/client/components/NavPane/NavPane.jsx
+++ b/client/components/NavPane/NavPane.jsx
@@ -3,7 +3,7 @@ import styled from "styled-components"
 import PropTypes from "prop-types"
 import { Loading } from "../Loading"
 import { connect } from "react-redux"
-import { spaces, colors } from "../../lib/styles"
+import { spaces, colors, media } from "../../lib/styles"
 import { receiveBoundaries } from "../../boundaries/actions"
 import PolygonList from "../PolygonList"
 
@@ -17,6 +17,9 @@ const Container = styled.nav`
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.3);
   padding: ${spaces.md};
   min-width: 250px;
+
+  ${media.tablet`flex-basis: 1 1 30vh; height: 50%;`}
+  ${media.mobileM`flex-basis: 1 1 30vh; height: 50%;`}
 `
 
 const HeaderContainer = styled.div`

--- a/client/components/UserInterface/UserInterface.jsx
+++ b/client/components/UserInterface/UserInterface.jsx
@@ -2,13 +2,22 @@ import React, { Component } from "react"
 import styled from "styled-components"
 import Map from "../Map"
 import NavPane from "../NavPane"
-import { fonts } from "../../lib/styles"
+import { fonts, media } from "../../lib/styles"
 
 const Container = styled.div`
   display: flex;
   z-index: -1;
   font-family: "Source Code Pro", monospace;
   font-size: ${fonts.base};
+
+  ${media.tablet`
+      flex-direction: column;
+      height: 50em;
+   `}
+  ${media.mobileM`
+      flex-direction: column;
+      height: 50em;
+   `}
 `
 
 export default class UserInterface extends Component {

--- a/client/lib/styles/media.js
+++ b/client/lib/styles/media.js
@@ -1,20 +1,23 @@
-const size = {
-  mobileS: "320px",
-  mobileM: "375px",
-  mobileL: "425px",
-  tablet: "768px",
-  laptop: "1024px",
-  laptopL: "1440px",
-  desktop: "2560px"
+import { css } from "styled-components"
+
+const sizes = {
+  mobileS: 320,
+  mobileM: 375,
+  mobileL: 425,
+  tablet: 768,
+  laptop: 1024,
+  laptopL: 1440,
+  desktop: 2560
 }
 
-export default {
-  mobileS: `(min-width: ${size.mobileS})`,
-  mobileM: `(min-width: ${size.mobileM})`,
-  mobileL: `(min-width: ${size.mobileL})`,
-  tablet: `(min-width: ${size.tablet})`,
-  laptop: `(min-width: ${size.laptop})`,
-  laptopL: `(min-width: ${size.laptopL})`,
-  desktop: `(min-width: ${size.desktop})`,
-  desktopL: `(min-width: ${size.desktop})`
-}
+const media = Object.keys(sizes).reduce((acc, label) => {
+  acc[label] = (...args) => css`
+    @media (max-width: ${sizes[label] / 16}em) {
+      ${css(...args)}
+    }
+  `
+
+  return acc
+}, {})
+
+export default media


### PR DESCRIPTION
What was done: 

```
Media queries added for styled components
Added for mobileM and tablet
Refactored our media directory as recommended by api
```